### PR TITLE
Completed percent error fix

### DIFF
--- a/RealTimeReport/src/report/realtime/datahandler/DataPreparator.java
+++ b/RealTimeReport/src/report/realtime/datahandler/DataPreparator.java
@@ -161,10 +161,12 @@ public class DataPreparator {
 		List<ExMethodResultDTO> resultDTOs = new ArrayList<ExMethodResultDTO>();
 		ExMethodResultDTO dto;
 		for (ITestNGMethod iTestNGMethod : suite.getExcludedMethods()) {
-			dto = new ExMethodResultDTO();
-			dto.setDataProvider(getDataProvider(iTestNGMethod));
-			dto.setExcludedMethod(iTestNGMethod.getMethodName());
-			resultDTOs.add(dto);
+			if(iTestNGMethod.isTest()){
+				dto = new ExMethodResultDTO();
+				dto.setDataProvider(getDataProvider(iTestNGMethod));
+				dto.setExcludedMethod(iTestNGMethod.getMethodName());
+				resultDTOs.add(dto);
+			}
 		}
 		return resultDTOs;
 	}


### PR DESCRIPTION
The completed percentage is coming more than 100%. The problem was - TestNG captures the excluded `@Test` methods list which are not really excluded by user, they are the configuration methods (i.e @BeforeTest etc..). So, now an extra check is applied from our code end to verify whether the `excluded` methods reported by TestNG is `@Test` annotated method or not.